### PR TITLE
fix: Prometheus-exporter race for incremental counters not monotonically accumulating correctly.

### DIFF
--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -588,7 +588,8 @@ impl StreamSink<Event> for PrometheusExporter {
                                     finalizers.update_status(EventStatus::Delivered);
                                 }
                                 Entry::Vacant(entry) => {
-                                    // First occurrence - convert to absolute and store
+                                    // Otherwise, if we didn't have an existing value or we did and it was not
+                                    // compatible with the new value, simply return the new value as absolute.
                                     entry.insert((preprocessed_metric.into_absolute(), MetricMetadata::new(flush_period)));
                                     finalizers.update_status(EventStatus::Delivered);
                                 }

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -483,7 +483,11 @@ impl PrometheusExporter {
         Ok(())
     }
 
-    fn normalize(&mut self, metric: Metric) -> Option<Metric> {
+    /// Preprocesses a metric by converting distributions to the appropriate format.
+    ///
+    /// For distribution metrics, converts them to either histograms or summaries based on
+    /// configuration. Absolute and incremental metrics are returned as-is.
+    fn preprocess_metric(&mut self, metric: Metric) -> Option<Metric> {
         let new_metric = match metric.value() {
             MetricValue::Distribution { .. } => {
                 // Convert the distribution as-is, and then absolute-ify it.
@@ -553,29 +557,27 @@ impl StreamSink<Event> for PrometheusExporter {
             let mut metric = event.into_metric();
             let finalizers = metric.take_finalizers();
 
-            match self.normalize(metric) {
-                Some(normalized) => {
-                    let normalized = if self.config.suppress_timestamp {
-                        normalized.with_timestamp(None)
-                    } else {
-                        normalized
-                    };
+            match self.preprocess_metric(metric) {
+                Some(mut preprocessed_metric) => {
+                    if self.config.suppress_timestamp {
+                        preprocessed_metric = preprocessed_metric.with_timestamp(None);
+                    }
 
                     // Handle metric storage based on kind. For incremental metrics, we must
                     // accumulate atomically under write lock to prevent race conditions.
-                    match normalized.kind() {
+                    match preprocessed_metric.kind() {
                         MetricKind::Absolute => {
                             // Absolute metrics are already in final form, just store them
                             let mut metrics = self.metrics.write().expect(LOCK_FAILED);
 
-                            match metrics.entry(MetricRef::from_metric(&normalized)) {
+                            match metrics.entry(MetricRef::from_metric(&preprocessed_metric)) {
                                 Entry::Occupied(mut entry) => {
                                     let (data, metadata) = entry.get_mut();
-                                    *data = normalized;
+                                    *data = preprocessed_metric;
                                     metadata.refresh();
                                 }
                                 Entry::Vacant(entry) => {
-                                    entry.insert((normalized, MetricMetadata::new(flush_period)));
+                                    entry.insert((preprocessed_metric, MetricMetadata::new(flush_period)));
                                 }
                             }
                             finalizers.update_status(EventStatus::Delivered);
@@ -583,7 +585,7 @@ impl StreamSink<Event> for PrometheusExporter {
                         MetricKind::Incremental => {
                             // For incremental metrics, accumulate atomically under write lock
                             let mut metrics = self.metrics.write().expect(LOCK_FAILED);
-                            let metric_ref = MetricRef::from_metric(&normalized);
+                            let metric_ref = MetricRef::from_metric(&preprocessed_metric);
 
                             match metrics.entry(metric_ref) {
                                 Entry::Occupied(mut entry) => {
@@ -591,20 +593,19 @@ impl StreamSink<Event> for PrometheusExporter {
 
                                     // Atomically read current value, add increment, and store
                                     let mut accumulated_value = existing_metric.value().clone();
-                                    if accumulated_value.add(normalized.value()) {
+                                    if accumulated_value.add(preprocessed_metric.value()) {
                                         // Successfully accumulated - store as absolute
-                                        *existing_metric = normalized.with_value(accumulated_value).into_absolute();
-                                        metadata.refresh();
-                                        finalizers.update_status(EventStatus::Delivered);
+                                        *existing_metric = preprocessed_metric.with_value(accumulated_value).into_absolute();
                                     } else {
-                                        // Incompatible metric values
-                                        emit!(PrometheusNormalizationError {});
-                                        finalizers.update_status(EventStatus::Errored);
+                                        // Incompatible metric types - treat increment as absolute
+                                        *existing_metric = preprocessed_metric.into_absolute();
                                     }
+                                    metadata.refresh();
+                                    finalizers.update_status(EventStatus::Delivered);
                                 }
                                 Entry::Vacant(entry) => {
                                     // First occurrence - convert to absolute and store
-                                    entry.insert((normalized.into_absolute(), MetricMetadata::new(flush_period)));
+                                    entry.insert((preprocessed_metric.into_absolute(), MetricMetadata::new(flush_period)));
                                     finalizers.update_status(EventStatus::Delivered);
                                 }
                             }

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -513,21 +513,10 @@ impl PrometheusExporter {
         match new_metric.kind() {
             MetricKind::Absolute => Some(new_metric),
             MetricKind::Incremental => {
-                let metrics = self.metrics.read().expect(LOCK_FAILED);
-                let metric_ref = MetricRef::from_metric(&new_metric);
-
-                if let Some(existing) = metrics.get(&metric_ref) {
-                    let mut current = existing.0.value().clone();
-                    if current.add(new_metric.value()) {
-                        // If we were able to add to the existing value (i.e. they were compatible),
-                        // return the result as an absolute metric.
-                        return Some(new_metric.with_value(current).into_absolute());
-                    }
-                }
-
-                // Otherwise, if we didn't have an existing value or we did and it was not
-                // compatible with the new value, simply return the new value as absolute.
-                Some(new_metric.into_absolute())
+                // For incremental metrics, return as-is to be accumulated atomically later.
+                // We don't accumulate here to avoid a race condition between reading the current
+                // value under READ lock and storing the accumulated value under WRITE lock.
+                Some(new_metric)
             }
         }
     }
@@ -572,21 +561,55 @@ impl StreamSink<Event> for PrometheusExporter {
                         normalized
                     };
 
-                    // We have a normalized metric, in absolute form.  If we're already aware of this
-                    // metric, update its expiration deadline, otherwise, start tracking it.
-                    let mut metrics = self.metrics.write().expect(LOCK_FAILED);
+                    // Handle metric storage based on kind. For incremental metrics, we must
+                    // accumulate atomically under write lock to prevent race conditions.
+                    match normalized.kind() {
+                        MetricKind::Absolute => {
+                            // Absolute metrics are already in final form, just store them
+                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
 
-                    match metrics.entry(MetricRef::from_metric(&normalized)) {
-                        Entry::Occupied(mut entry) => {
-                            let (data, metadata) = entry.get_mut();
-                            *data = normalized;
-                            metadata.refresh();
+                            match metrics.entry(MetricRef::from_metric(&normalized)) {
+                                Entry::Occupied(mut entry) => {
+                                    let (data, metadata) = entry.get_mut();
+                                    *data = normalized;
+                                    metadata.refresh();
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert((normalized, MetricMetadata::new(flush_period)));
+                                }
+                            }
+                            finalizers.update_status(EventStatus::Delivered);
                         }
-                        Entry::Vacant(entry) => {
-                            entry.insert((normalized, MetricMetadata::new(flush_period)));
+                        MetricKind::Incremental => {
+                            // For incremental metrics, accumulate atomically under write lock
+                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
+                            let metric_ref = MetricRef::from_metric(&normalized);
+
+                            match metrics.entry(metric_ref) {
+                                Entry::Occupied(mut entry) => {
+                                    let (existing_metric, metadata) = entry.get_mut();
+
+                                    // Atomically read current value, add increment, and store
+                                    let mut accumulated_value = existing_metric.value().clone();
+                                    if accumulated_value.add(normalized.value()) {
+                                        // Successfully accumulated - store as absolute
+                                        *existing_metric = normalized.with_value(accumulated_value).into_absolute();
+                                        metadata.refresh();
+                                        finalizers.update_status(EventStatus::Delivered);
+                                    } else {
+                                        // Incompatible metric values
+                                        emit!(PrometheusNormalizationError {});
+                                        finalizers.update_status(EventStatus::Errored);
+                                    }
+                                }
+                                Entry::Vacant(entry) => {
+                                    // First occurrence - convert to absolute and store
+                                    entry.insert((normalized.into_absolute(), MetricMetadata::new(flush_period)));
+                                    finalizers.update_status(EventStatus::Delivered);
+                                }
+                            }
                         }
                     }
-                    finalizers.update_status(EventStatus::Delivered);
                 }
                 _ => {
                     emit!(PrometheusNormalizationError {});

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -563,18 +563,17 @@ impl StreamSink<Event> for PrometheusExporter {
                         preprocessed_metric = preprocessed_metric.with_timestamp(None);
                     }
 
-                    // Handle metric storage based on kind. For incremental metrics, we must
-                    // accumulate atomically under write lock to prevent race conditions.
-                    match preprocessed_metric.kind() {
-                        MetricKind::Incremental => {
-                            // For incremental metrics, accumulate atomically under write lock
-                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
-                            let metric_ref = MetricRef::from_metric(&preprocessed_metric);
+                    // Handle metric storage. For incremental metrics, we must accumulate
+                    // atomically under write lock to prevent race conditions.
+                    let mut metrics = self.metrics.write().expect(LOCK_FAILED);
+                    let metric_ref = MetricRef::from_metric(&preprocessed_metric);
 
-                            match metrics.entry(metric_ref) {
-                                Entry::Occupied(mut entry) => {
-                                    let (existing_metric, metadata) = entry.get_mut();
+                    match metrics.entry(metric_ref) {
+                        Entry::Occupied(mut entry) => {
+                            let (existing_metric, metadata) = entry.get_mut();
 
+                            match preprocessed_metric.kind() {
+                                MetricKind::Incremental => {
                                     // Atomically read current value, add increment, and store
                                     let mut accumulated_value = existing_metric.value().clone();
                                     if accumulated_value.add(preprocessed_metric.value()) {
@@ -584,34 +583,24 @@ impl StreamSink<Event> for PrometheusExporter {
                                         // Incompatible metric types - treat increment as absolute
                                         *existing_metric = preprocessed_metric.into_absolute();
                                     }
-                                    metadata.refresh();
-                                    finalizers.update_status(EventStatus::Delivered);
                                 }
-                                Entry::Vacant(entry) => {
-                                    // Otherwise, if we didn't have an existing value or we did and it was not
-                                    // compatible with the new value, simply return the new value as absolute.
-                                    entry.insert((preprocessed_metric.into_absolute(), MetricMetadata::new(flush_period)));
-                                    finalizers.update_status(EventStatus::Delivered);
+                                _ => {
+                                    // For all other metric kinds (currently just Absolute), replace directly
+                                    *existing_metric = preprocessed_metric;
                                 }
                             }
+                            metadata.refresh();
                         }
-                        _ => {
-                            // For all other metric kinds, store as-is
-                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
-
-                            match metrics.entry(MetricRef::from_metric(&preprocessed_metric)) {
-                                Entry::Occupied(mut entry) => {
-                                    let (data, metadata) = entry.get_mut();
-                                    *data = preprocessed_metric;
-                                    metadata.refresh();
-                                }
-                                Entry::Vacant(entry) => {
-                                    entry.insert((preprocessed_metric, MetricMetadata::new(flush_period)));
-                                }
-                            }
-                            finalizers.update_status(EventStatus::Delivered);
+                        Entry::Vacant(entry) => {
+                            // First occurrence of this metric
+                            let stored_metric = match preprocessed_metric.kind() {
+                                MetricKind::Incremental => preprocessed_metric.into_absolute(),
+                                _ => preprocessed_metric,
+                            };
+                            entry.insert((stored_metric, MetricMetadata::new(flush_period)));
                         }
                     }
+                    finalizers.update_status(EventStatus::Delivered);
                 }
                 _ => {
                     emit!(PrometheusNormalizationError {});

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -566,22 +566,6 @@ impl StreamSink<Event> for PrometheusExporter {
                     // Handle metric storage based on kind. For incremental metrics, we must
                     // accumulate atomically under write lock to prevent race conditions.
                     match preprocessed_metric.kind() {
-                        MetricKind::Absolute => {
-                            // Absolute metrics are already in final form, just store them
-                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
-
-                            match metrics.entry(MetricRef::from_metric(&preprocessed_metric)) {
-                                Entry::Occupied(mut entry) => {
-                                    let (data, metadata) = entry.get_mut();
-                                    *data = preprocessed_metric;
-                                    metadata.refresh();
-                                }
-                                Entry::Vacant(entry) => {
-                                    entry.insert((preprocessed_metric, MetricMetadata::new(flush_period)));
-                                }
-                            }
-                            finalizers.update_status(EventStatus::Delivered);
-                        }
                         MetricKind::Incremental => {
                             // For incremental metrics, accumulate atomically under write lock
                             let mut metrics = self.metrics.write().expect(LOCK_FAILED);
@@ -609,6 +593,22 @@ impl StreamSink<Event> for PrometheusExporter {
                                     finalizers.update_status(EventStatus::Delivered);
                                 }
                             }
+                        }
+                        _ => {
+                            // For all other metric kinds, store as-is
+                            let mut metrics = self.metrics.write().expect(LOCK_FAILED);
+
+                            match metrics.entry(MetricRef::from_metric(&preprocessed_metric)) {
+                                Entry::Occupied(mut entry) => {
+                                    let (data, metadata) = entry.get_mut();
+                                    *data = preprocessed_metric;
+                                    metadata.refresh();
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert((preprocessed_metric, MetricMetadata::new(flush_period)));
+                                }
+                            }
+                            finalizers.update_status(EventStatus::Delivered);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Fixed a race condition in `src/sinks/prometheus/exporter.rs` that caused counter metrics to decrease between Prometheus scrapes and led to inflated rate calculations at high throughput.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
The `normalize()` method was performing non-atomic read-modify-write operations for incremental counter metrics

1. **Acquire READ lock** → Read current counter value
2. **Release READ lock**
3. Calculate new accumulated value
4. **Later, acquire WRITE lock** → Store pre-calculated value

At high throughput, multiple events could read the same old value, calculate their increments independently, and then overwrite each other when storing. Without this fix it could result in:
- Counters to **decrease** between scrapes
- Prometheus `rate()` to interpret decreases as counter resets
- `rate()` calculations being heavily inflated to very large values


The fix was for incremental counters to acquire a lock 1 to both `READ` the old incremental value, then `WRITE` the new accumulate incremental value in one atomic operation. 

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
